### PR TITLE
expand plots based on number of inputs

### DIFF
--- a/main.py
+++ b/main.py
@@ -70,7 +70,7 @@ class Main:
         ax.bar_label(rects3, padding=3)
         fig.tight_layout()
         plt.savefig('charts/' + title)
-        # plt.show()
+        plt.show()
 
     def __run_heuristics_by_depth_experiments(self) -> None:
         num_iterations = 50

--- a/main.py
+++ b/main.py
@@ -26,9 +26,9 @@ class Main:
             self.__plot_results(
                 baseline=baseline,
                 testplayers=testplayers,
-                iterations=iterations, 
-                wins=test_player_wins, 
-                losses=baseline_wins, 
+                iterations=iterations,
+                wins=test_player_wins,
+                losses=baseline_wins,
                 draws=draws
                 )
 
@@ -37,11 +37,11 @@ class Main:
 
     def __plot_results(
         self,
-        baseline: ChessPlayer, 
-        testplayers: List[ChessPlayer], 
-        iterations: int, 
-        wins: list[int], 
-        losses: list[int], 
+        baseline: ChessPlayer,
+        testplayers: List[ChessPlayer],
+        iterations: int,
+        wins: list[int],
+        losses: list[int],
         draws: list[int]
     ) -> None:
         title = 'Baseline: ' + baseline.get_name() + '\n' + str(iterations) + \
@@ -54,7 +54,7 @@ class Main:
         r2 = [x + width for x in r1]
         r3 = [x + width for x in r2]
 
-        fig, ax = plt.subplots()
+        fig, ax = plt.subplots(figsize=((len(labels)*1.85),6))
         rects1 = ax.bar(r1, wins, width, label='Test Player Wins')
         rects2 = ax.bar(r2, losses, width, label='Baseline Wins')
         rects3 = ax.bar(r3, draws, width, label='Draws')
@@ -63,31 +63,31 @@ class Main:
         ax.set_xlabel('Player Type')
         ax.set_title(title)
         ax.set_xticks(x, labels)
-        ax.legend()
+        ax.legend(bbox_to_anchor=(.2,1.2,0,0))
 
         ax.bar_label(rects1, padding=3)
         ax.bar_label(rects2, padding=3)
         ax.bar_label(rects3, padding=3)
         fig.tight_layout()
         plt.savefig('charts/' + title)
-        plt.show()
+        # plt.show()
 
     def __run_heuristics_by_depth_experiments(self) -> None:
         num_iterations = 50
         depth_iterations = [1, 2, 3]
         baselines =  [MinimaxPlayer(
-            depth=depth, 
+            depth=depth,
             heuristics=[Heuristic.Distance_From_Starting_Location, Heuristic.Maximize_Number_Of_Pieces],
             run_alpha_beta=True) \
                 for depth in depth_iterations]
         testplayers = [
             MinimaxPlayer(
-                depth=depth, 
+                depth=depth,
                 heuristics=[
-                    Heuristic.Piece_Could_Be_Captured, 
-                    Heuristic.Distance_From_Starting_Location, 
-                    Heuristic.Keep_Pawns_Diagonally_Supported, 
-                    Heuristic.Stacked_Pawns, 
+                    Heuristic.Piece_Could_Be_Captured,
+                    Heuristic.Distance_From_Starting_Location,
+                    Heuristic.Keep_Pawns_Diagonally_Supported,
+                    Heuristic.Stacked_Pawns,
                     Heuristic.Maximize_Number_Of_Pieces
                 ],
                 run_alpha_beta=True


### PR DESCRIPTION
The x axis is now scaled based on the number of test inputs.
The Legend will now display outside the bounding box of the plot on the left side. It does change position a little, so later improvements could be to anchor it on the edge.

Trailing spaces from the file get removed automatically by my vim configuration when I save, just so all the lines changing doesn't surprise anyone.

<img width="695" alt="Screenshot 2022-12-01 at 9 08 00 AM" src="https://user-images.githubusercontent.com/66976595/205115729-dc72134a-7279-4d15-be8b-35a957c7f785.png">
