### PR TITLE
Fixed bug in alpha_beta_pruning

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,7 @@ from typing import List
 
 class Main:
     def run(self) -> None:
-        self.__run_minimax_with_heuristics_vs_random()
+        self.__run_heuristics_by_depth_experiments()
 
     def __run_and_plot_one_experiment(self, iterations: int, baselines: List[ChessPlayer], testplayers: List[ChessPlayer]) -> None:
         test_results: List[List[Results]] = AIChess(iterations=iterations, baselines=baselines, testplayers=testplayers).run()

--- a/minimaxchessplayer.py
+++ b/minimaxchessplayer.py
@@ -173,15 +173,21 @@ class MinimaxPlayer(ChessPlayer):
         return np.array(nodes)
 
     def alpha_beta_pruning(self, max_player: chess.Color, value: int, children: np.array(Node), child_index: int) -> bool:
+        is_max_player = True if max_player == children[child_index].parent.board.turn else False
+
         value = max(value, children[child_index].reward_if_taking_best_move) \
-            if max_player == children[child_index].parent.board.turn \
-            else min(value, children[child_index].reward_if_taking_best_move)
+            if is_max_player else min(value, children[child_index].reward_if_taking_best_move)
 
-        if value >= children[child_index].parent.beta or value <= children[child_index].parent.alpha:
-            return True
-
-        children[child_index].parent.alpha = max(children[child_index].parent.alpha, value)
-        children[child_index].parent.beta = min(children[child_index].parent.beta, value)
+        # Do beta pruning only if maximizer
+        if is_max_player:
+            if value >= children[child_index].parent.beta:
+                return True
+            children[child_index].parent.alpha = max(children[child_index].parent.alpha, value)
+        # Do alpha pruning only if minimizer
+        else:
+            if value <= children[child_index].parent.alpha:
+                return True
+            children[child_index].parent.beta = min(children[child_index].parent.beta, value)
         return False
 
     def calc_reward(self,board: AIChessBoard, root_board: Node) -> int:


### PR DESCRIPTION
I found a bug with the condensed version of alpha_beta_pruning. We need to add back in minimizer and maximizer checks to determine whether alpha or beta pruning needs to occur. The bug with the condensed version occurs when (for example) it's the maximizer's turn and one of the child's reward values is less than the current alpha but still less than the beta value. This causes alpha pruning at a maximizer level (which we don't want) and the real value that would have been chosen gets missed. This can occur with the same idea at the minimizer level but with beta pruning.

After adding checks back in, the results compared to minimax without alpha_beta_pruning looked more than what I would expect. I tracked the logic with an alpha_beta pruning tree which is how I found the bug. 