### PR TITLE
Reformatted alpha-beta pruning

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,8 +19,8 @@ class Main:
     def run(self) -> None:
         # self.__run_heuristics_by_depth_experiments()
         # self.__run_heuristics_ablation_study()
-        self.__run_minimax_with_heuristics_vs_random()
-        # self.__compare_runtimes_of_basic_configs()
+        # self.__run_minimax_with_heuristics_vs_random()
+         self.__compare_runtimes_of_basic_configs()
 
     def __run_and_plot_one_experiment(self, iterations: int, baselines: List[ChessPlayer], testplayers: List[ChessPlayer], title_addition: str) -> None:
         test_results: List[List[Results]] = AIChess(iterations=iterations, baselines=baselines, testplayers=testplayers).run()
@@ -112,18 +112,18 @@ class Main:
             ax.bar_label(rect, padding=3)
 
         fig.tight_layout()
-        plt.savefig('charts/' + title_of_saved_file + "-" + graph_type)
+ #       plt.savefig('charts/' + title_of_saved_file + "-" + graph_type)
         plt.show()
 
     def __run_heuristics_by_depth_experiments(self) -> None:
         title = "Heuristics by Depth"
         num_iterations = 50
-        depth_iterations = [1, 2, 3, 4, 5]
+        depth_iterations = [1, 2, 3]
         baselines =  [MinimaxPlayer(
             time=time,
             depth=depth,
             heuristics=[Heuristic.Distance_From_Starting_Location, Heuristic.Maximize_Number_Of_Pieces],
-            run_alpha_beta=True) \
+            run_alpha_beta=False) \
                 for depth in depth_iterations]
         testplayers = [
             MinimaxPlayer(
@@ -136,7 +136,7 @@ class Main:
                     Heuristic.Stacked_Pawns,
                     Heuristic.Maximize_Number_Of_Pieces
                 ],
-                run_alpha_beta=True
+                run_alpha_beta=False
             ) for depth in depth_iterations]
         self.__run_and_plot_one_experiment(iterations=num_iterations, baselines=baselines, testplayers=testplayers, title_addition=title)
 
@@ -193,6 +193,12 @@ class Main:
                 depth=depth,
                 heuristics=[],
                 run_alpha_beta=False
+            ),
+            MinimaxPlayer(
+                time=time,
+                depth=depth,
+                heuristics=[],
+                run_alpha_beta=True
             ),
             MinimaxPlayer(
                 time=time,

--- a/main.py
+++ b/main.py
@@ -112,7 +112,7 @@ class Main:
             ax.bar_label(rect, padding=3)
 
         fig.tight_layout()
- #       plt.savefig('charts/' + title_of_saved_file + "-" + graph_type)
+        plt.savefig('charts/' + title_of_saved_file + "-" + graph_type)
         plt.show()
 
     def __run_heuristics_by_depth_experiments(self) -> None:

--- a/minimaxchessplayer.py
+++ b/minimaxchessplayer.py
@@ -115,7 +115,7 @@ class MinimaxPlayer(ChessPlayer):
             return current
 
         # Unpack each move to see the states
-        children: np.array(Node) = self.unpack(maximizer=root_board.turn, root=current, depth=depth, true_root=root_board)
+        children: np.array(Node) = self.unpack(root=current)
 
         # Check if no viable moves are left in this path
         if children.size == 0:
@@ -143,7 +143,7 @@ class MinimaxPlayer(ChessPlayer):
 
 
     # Unpack nodes into their child states
-    def unpack(self, maximizer: chess.Color, root: Node, depth: int, true_root: Node) -> np.array(Node):
+    def unpack(self, root: Node) -> np.array(Node):
 
         base_board: AIChessBoard = root.board
         legalmoves = np.array(list(root.board.legal_moves))

--- a/test_minimaxchessplayer.py
+++ b/test_minimaxchessplayer.py
@@ -12,16 +12,17 @@ WINNING_BOARD_FOR_WHITE = 'P7/1ppppppp/8/8/8/8/1PPPPPPP/8'
 WINNING_BOARD_FOR_BLACK = '8/1ppppppp/8/8/8/8/1PPPPPPP/p7'
 NOT_WINNING_BOARD = '8/1ppppppp/8/8/8/8/1PPPPPPP/8'
 
+
 class TestMinimaxChessPlayer:
     def test_node_creation(self) -> None:
         board = AIChessBoard()
         move = Move('a2', 'a3')
         node = Node(
             reward_if_taking_best_move=1,
-            board=board, 
+            board=board,
             move_that_generated_this_board=move,
             best_move_from_board=None,
-            win_status=1, 
+            win_status=1,
             alpha=0,
             beta=0,
             parent=None
@@ -33,26 +34,26 @@ class TestMinimaxChessPlayer:
         move = Move('a2', 'a3')
         node1 = Node(
             reward_if_taking_best_move=1,
-            board=board, 
+            board=board,
             move_that_generated_this_board=move,
             best_move_from_board=None,
-            win_status=1, 
+            win_status=1,
             alpha=0,
             beta=0,
             parent=None
         )
         node2 = node1.copy()
         assert node1 == node2
- 
+
     def test_unequal_nodes_evaluate_as_not_equal(self) -> None:
         board = AIChessBoard()
         move = Move('a2', 'a3')
         node1 = Node(
             reward_if_taking_best_move=1,
-            board=board, 
+            board=board,
             move_that_generated_this_board=move,
             best_move_from_board=None,
-            win_status=1, 
+            win_status=1,
             alpha=0,
             beta=0,
             parent=None
@@ -100,12 +101,12 @@ class TestMinimaxChessPlayer:
         assert unpacked_moves == set(board.legal_moves)
 
     def __check_reward(
-        self, 
-        maximizer: chess.Color, 
-        board_fen: str, 
-        player_wins: bool,
-        player_loses: bool, 
-        max_depth_reached: bool
+            self,
+            maximizer: chess.Color,
+            board_fen: str,
+            player_wins: bool,
+            player_loses: bool,
+            max_depth_reached: bool
     ) -> None:
         board = AIChessBoard(board_fen)
         board.turn = maximizer
@@ -122,7 +123,7 @@ class TestMinimaxChessPlayer:
         minimaxplayer = MinimaxPlayer(time, depth=1, heuristics=[], run_alpha_beta=False)
         result_reward = minimaxplayer.check_terminal_state(
             current=current,
-            root_board=current.board, 
+            root_board=current.board,
             depth=0 if max_depth_reached else 1,
             maximizer=maximizer
         )
@@ -138,52 +139,52 @@ class TestMinimaxChessPlayer:
 
     def test_check_terminal_state_returns_reward_if_white_is_maximizer_and_wins2(self) -> None:
         self.__check_reward(
-            maximizer=chess.WHITE, 
+            maximizer=chess.WHITE,
             board_fen=WINNING_BOARD_FOR_WHITE,
             player_wins=True,
             player_loses=False,
             max_depth_reached=False
         )
-        
+
     def test_negative_reward_returned_if_white_is_maximizer_and_loses(self) -> None:
         self.__check_reward(
-            maximizer=chess.WHITE, 
+            maximizer=chess.WHITE,
             board_fen=WINNING_BOARD_FOR_BLACK,
             player_wins=False,
             player_loses=True,
             max_depth_reached=False
         )
-        
+
     def test_check_terminal_state_returns_reward_if_black_is_maximizer_and_wins(self) -> None:
         self.__check_reward(
-            maximizer=chess.BLACK, 
+            maximizer=chess.BLACK,
             board_fen=WINNING_BOARD_FOR_BLACK,
             player_wins=True,
             player_loses=False,
             max_depth_reached=False
         )
-        
+
     def test_negative_reward_returned_if_black_is_maximizer_and_loses(self) -> None:
         self.__check_reward(
-            maximizer=chess.BLACK, 
+            maximizer=chess.BLACK,
             board_fen=WINNING_BOARD_FOR_WHITE,
             player_wins=False,
             player_loses=True,
             max_depth_reached=False
         )
-        
+
     def test_check_terminal_state_returns_no_reward_if_max_depth_reached(self) -> None:
         self.__check_reward(
-            maximizer=chess.BLACK, 
+            maximizer=chess.BLACK,
             board_fen=NOT_WINNING_BOARD,
             player_wins=False,
             player_loses=False,
             max_depth_reached=True
         )
-        
+
     def test_none_returned_if_not_terminal_state(self) -> None:
         self.__check_reward(
-            maximizer=chess.BLACK, 
+            maximizer=chess.BLACK,
             board_fen=NOT_WINNING_BOARD,
             player_wins=False,
             player_loses=False,
@@ -208,7 +209,7 @@ class TestMinimaxChessPlayer:
         minimaxplayer = MinimaxPlayer(time, depth=3, heuristics=[], run_alpha_beta=False)
         result = minimaxplayer.pre_order(root_board=board, current=node, depth=minimaxplayer.depth)
         assert result.best_move_from_board == best_move
-        
+
     def test_exception_thrown_if_no_moves_possible(self) -> None:
         board_fen = '8/1p1p4/1P1P4/8/8/8/8/8'
         board = AIChessBoard(board_fen)
@@ -225,7 +226,7 @@ class TestMinimaxChessPlayer:
         minimaxplayer = MinimaxPlayer(time, depth=3, heuristics=[], run_alpha_beta=False)
         with pytest.raises(ChessPlayer.ChessPlayerException):
             minimaxplayer.get_next_move(board=board)
-        
+
     def test_get_next_move_returns_best_move(self) -> None:
         board_fen = '8/1p1p4/8/8/8/5p2/1P1P4/8'
         best_move = Move.from_uci('f3f2')
@@ -279,42 +280,56 @@ class TestMinimaxChessPlayer:
         minimizer = True if (root.board.turn != chess.WHITE) else False
         assert maximizer is True and minimizer is False
 
-    # This test needs fixed...
-    # def test_alpha_beta_pruning_returns_pruned_array_of_legal_moves(self) -> None:
-    #     board = AIChessBoard(NOT_WINNING_BOARD)
-    #     minimaxplayer = MinimaxPlayer(time, depth=1, heuristics=[], run_alpha_beta=False)
-    #     root = Node(
-    #         reward_if_taking_best_move=0,
-    #         board=board,
-    #         move_that_generated_this_board=None,
-    #         best_move_from_board=None,
-    #         win_status=None,
-    #         alpha=ALPHA_DEFAULT,
-    #         beta=BETA_DEFAULT,
-    #         parent=None
-    #     )
-    #     legalmoves = np.array(list(root.board.legal_moves))
-    #     nodes = np.empty(len(legalmoves), dtype=Move)
-    #     base_board: AIChessBoard = root.board
-    #     new_board = base_board.copy()
-    #     new_board.push(legalmoves[0])
-    #     new_board.turn = not base_board.turn
+    def test_alpha_beta_pruning_returns_true_when_beta_pruning_occurs(self) -> None:
+        parent_board = AIChessBoard(WINNING_BOARD_FOR_BLACK)
+        board = AIChessBoard(WINNING_BOARD_FOR_WHITE)
+        alphabetaplayer = MinimaxPlayer(time, depth=1, heuristics=[], run_alpha_beta=True)
+        ancestor = Node(
+            reward_if_taking_best_move=0,
+            board=parent_board,
+            move_that_generated_this_board=None,
+            best_move_from_board=None,
+            win_status=None,
+            alpha=ALPHA_DEFAULT,
+            beta=0,
+            parent=None
+        )
+        current = Node(
+            reward_if_taking_best_move=0,
+            board=board,
+            move_that_generated_this_board=None,
+            best_move_from_board=None,
+            win_status=None,
+            alpha=10,
+            beta=BETA_DEFAULT,
+            parent=ancestor
+        )
+        is_pruned = alphabetaplayer.alpha_beta_pruning(max_player=chess.WHITE, child=None, current=current)
+        assert is_pruned == True
 
-    #     nodes[0] = Node(
-    #         reward_if_taking_best_move=0,
-    #         board=board,
-    #         move_that_generated_this_board=legalmoves[0],
-    #         best_move_from_board=None,
-    #         win_status=None,  # taken care of by recursive call
-    #         alpha=root.alpha,
-    #         beta=root.beta,
-    #         parent=root
-    #     )
-
-    #     alpha_beta_moves = {node.move_that_generated_this_board for node in minimaxplayer.alpha_beta_pruning(
-    #         max_player=False,
-    #         value=root.alpha,
-    #         children=nodes,
-    #         child_index=0)}
-
-    #     assert alpha_beta_moves < set(board.legal_moves)
+    def test_alpha_beta_pruning_returns_true_when_alpha_pruning_occurs(self) -> None:
+        parent_board = AIChessBoard(WINNING_BOARD_FOR_WHITE)
+        board = AIChessBoard(WINNING_BOARD_FOR_BLACK)
+        alphabetaplayer = MinimaxPlayer(time, depth=1, heuristics=[], run_alpha_beta=True)
+        ancestor = Node(
+            reward_if_taking_best_move=0,
+            board=parent_board,
+            move_that_generated_this_board=None,
+            best_move_from_board=None,
+            win_status=None,
+            alpha=10,
+            beta=BETA_DEFAULT,
+            parent=None
+        )
+        current = Node(
+            reward_if_taking_best_move=0,
+            board=board,
+            move_that_generated_this_board=None,
+            best_move_from_board=None,
+            win_status=None,
+            alpha=ALPHA_DEFAULT,
+            beta=0,
+            parent=ancestor
+        )
+        is_pruned = alphabetaplayer.alpha_beta_pruning(max_player=chess.BLACK, child=None, current=current)
+        assert is_pruned == True


### PR DESCRIPTION
Reformatted alpha-beta pruning to occur after the recursive call in pre_order(). Also changed the pruning condition to compare to the ancestor alpha and beta value to the current node's opposing alpha or beta value which corrected the condition for pruning. 
Added a condition in __compare_runtimes_of_basic_configs to compare the no-heuristics tests between both ABP off and ABP on. 
Testing __compare_runtimes_of_basic_configs against random opponent baseline showed improvements compared to the last ABP pruning of a similar test.